### PR TITLE
Fix package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.mts"
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "main": "./dist/index.mjs",


### PR DESCRIPTION
We just updated to `typedoc` 0.27.x, which now relies on `shiki` (technically, a fork called `@gerrit0/mini-shiki`). However, when we run Jest tests on our code, we're now getting errors like `Cannot find module '@shikijs/vscode-textmate'`. After debugging quite a bit, it's happening because this package's `exports` are set to `import` so there is no way for the Jest resolver (which is CommonJS by default) to find the entry point for the module.

This does _not_ happen with other Shiki packages, like `@shikijs/engine-oniguruma`, define [a `default` export instead of `import`](https://github.com/shikijs/shiki/blob/d1c87faee7b65de788053fea8edc73a9ef0eee6d/packages/engine-oniguruma/package.json#L24), meaning that both CommonJS and ESM resolvers can find the entry point correctly.

This change follow that same pattern to make this package work correctly in a larger variety of situations - it converts the `import` key to `default` so that the Jest resolver can find it correctly.